### PR TITLE
Replaced 's' in Small FontProcess with 'ꜱ'

### DIFF
--- a/src/main/java/net/replaceitem/symbolchat/FontProcessor.java
+++ b/src/main/java/net/replaceitem/symbolchat/FontProcessor.java
@@ -189,10 +189,10 @@ public abstract class FontProcessor {
             char c = string.charAt(0);
 
             if(c >= 'A' && c <= 'Z') {
-                return "ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘǫʀsᴛᴜᴠᴡxʏᴢ".substring(c-'A',c-'A'+1);
+                return "ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘǫʀꜱᴛᴜᴠᴡxʏᴢ".substring(c-'A',c-'A'+1);
             }
             if(c >= 'a' && c <= 'z') {
-                return "ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘǫʀsᴛᴜᴠᴡxʏᴢ".substring(c-'a',c-'a'+1);
+                return "ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘǫʀꜱᴛᴜᴠᴡxʏᴢ".substring(c-'a',c-'a'+1);
             }
 
             return string;


### PR DESCRIPTION
Replaced character for improved small caps consistency.